### PR TITLE
feat(user): validate access token before saving user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-redux": "^9.2.0",
-        "react-router-dom": "^7.5.3"
+        "react-router-dom": "^7.5.3",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1917,6 +1918,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -3827,6 +3836,18 @@
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.5.3"
+    "react-router-dom": "^7.5.3",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/AuthCheck.tsx
+++ b/src/components/AuthCheck.tsx
@@ -2,32 +2,53 @@ import { useAuth0 } from '@auth0/auth0-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useLoginMutation } from '../services/authApi'
+import { useDispatch } from 'react-redux';
+import { setToken } from '../features/auth/authSlice';
 
 
 function AuthCheck() {
-  const { isAuthenticated, user, isLoading } = useAuth0()
+  const { isAuthenticated, user, isLoading, getAccessTokenSilently } = useAuth0()
   const navigate = useNavigate()
 
-  const [login, { isSuccess, isError, error }] = useLoginMutation()
+  const [login, { data, isSuccess, isError, error }] = useLoginMutation()
   const [hasCalledLogin, setHasCalledLogin] = useState(false)
+  
+const dispatch = useDispatch();
 
-  useEffect(() => {
+
+useEffect(() => {
+  const doLogin = async () => {
     if (isAuthenticated && user && !hasCalledLogin) {
+      const token = await getAccessTokenSilently();
+
+      dispatch(setToken(token));
       const userData = {
         nameUser: user.name,
         email: user.email
-      }
+      };
 
-      login(userData)
-      setHasCalledLogin(true)
+      console.log("authCheck: ", token)
+      login(userData); // <-- token se pasa a prepareHeaders
+      setHasCalledLogin(true);
     }
-  }, [isAuthenticated, user, hasCalledLogin, login])
+  };
+
+  doLogin();
+}, [isAuthenticated, user, hasCalledLogin, login, getAccessTokenSilently, dispatch]);
 
   useEffect(() => {
     if (isSuccess) {
-      navigate("/home")
+      console.log('Mensaje backend:', data); // acá ves el mensaje recibido
+      navigate('/home');
     }
-  }, [isSuccess, navigate])
+  }, [isSuccess, data, navigate]);
+
+  useEffect(() => {
+    if (isError) {
+      console.error('Error backend:', error);
+      // Podés mostrar mensaje de error en UI aquí
+    }
+  }, [isError, error]);
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center">

--- a/src/features/auth/authSlice.tsx
+++ b/src/features/auth/authSlice.tsx
@@ -1,0 +1,26 @@
+// src/features/auth/authSlice.ts
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  token: string | null;
+}
+
+const initialState: AuthState = {
+  token: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setToken: (state, action: PayloadAction<string>) => {
+      state.token = action.payload;
+    },
+    clearToken: (state) => {
+      state.token = null;
+    },
+  },
+});
+
+export const { setToken, clearToken } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -7,7 +7,7 @@ function MainLayout() {
   const navigate = useNavigate(); // Obtén la función navigate
 
   const handleLogout = () => {
-    logout({ logoutParams: { returnTo: '/auth/login' } });
+    logout();
   };
 
   if (isLoading) {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -20,7 +20,9 @@ export default function Router() {
         domain={domain}
         clientId={clientId}
         authorizationParams={{
-          redirect_uri: window.location.origin + "/auth/check", // <- Redirección segura post-login
+          redirect_uri: window.location.origin + "/auth/check",
+          audience: "http://localhost:8080/api", // 👈 Usa el "Identifier" de tu API registrada en Auth0
+          scope: "openid profile email"   // 👈 Esto asegura que venga el email y perfil en el token
         }}
       >
         <Routes>

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,4 +1,7 @@
+
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '../store/store';
+
 
 interface UserProfile {
   name: string;
@@ -8,17 +11,25 @@ interface UserProfile {
 
 const baseQuery = fetchBaseQuery({
   baseUrl: 'http://localhost:8080/api',
+  prepareHeaders: (headers, { getState }) => {
+    const token = (getState() as RootState).auth.token
+    console.log(" token" ,token)
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`)
+    }
+    return headers
+  }
 });
 
 export const authApi = createApi({
   reducerPath: 'authApi',
-  baseQuery: baseQuery,
+  baseQuery,
   endpoints: (builder) => ({
     login: builder.mutation({
       query: (userData) => ({
         url: '/users/register',
         method: 'POST',
-        body: userData,
+        body: userData
       }),
     }),
     // getUserProfile: builder.query<UserProfile, void>({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,11 +1,12 @@
+// src/app/store.ts
 import { configureStore } from '@reduxjs/toolkit';
 import { authApi } from '../services/authApi';
-
+import authReducer from '../features/auth/authSlice'; 
 
 export const store = configureStore({
   reducer: {
     [authApi.reducerPath]: authApi.reducer,
-    // Otros reducers de tu aplicación
+    auth: authReducer, 
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(authApi.middleware),


### PR DESCRIPTION
Este PR implementa la lógica de autenticación usando Auth0 en el frontend y la conexión con el backend para registrar/verificar usuarios mediante accessToken.

Cambios principales:
Se obtiene el accessToken con getAccessTokenSilently() desde Auth0.

Se configura RTK Query para enviar el token en la cabecera Authorization.

Se actualiza el backend para leer el email desde el JWT y registrar/verificar el usuario.

Se añade un slice de Redux para almacenar el token.

Se mejora la lógica de AuthCheck para evitar múltiples llamadas a login.

Consideraciones:
El token debe contener el email (verificado en jwt.io).

Se requiere configurar el audience correcto en Auth0 y en el backend.

Se recomienda revisar las acciones de login en Auth0 si el email no viene por defecto en el token.